### PR TITLE
Export `GetProcessor` as public trait for external consumer

### DIFF
--- a/src/conv_fft/mod.rs
+++ b/src/conv_fft/mod.rs
@@ -3,8 +3,6 @@
 //! This module offers the `ConvFFTExt` trait, which extends `ndarray`
 //! with FFT-based convolution methods.
 
-use std::fmt::Debug;
-
 use ndarray::{
     Array, ArrayBase, Data, Dim, IntoDimension, Ix, RawData, RemoveAxis, SliceArg, SliceInfo,
     SliceInfoElem,
@@ -172,7 +170,7 @@ impl<'a, T, InElem, S, SK, const N: usize> ConvFFTExt<'a, T, InElem, S, SK, N>
     for ArrayBase<S, Dim<[Ix; N]>>
 where
     T: NumAssign + FftNum,
-    InElem: processor::GetProcessor<T, InElem> + NumAssign + Copy + Debug,
+    InElem: processor::GetProcessor<T, InElem> + NumAssign + Copy,
     S: Data<Elem = InElem> + 'a,
     SK: Data<Elem = InElem> + 'a,
     [Ix; N]: IntoDimension<Dim = Dim<[Ix; N]>>,

--- a/src/conv_fft/padding.rs
+++ b/src/conv_fft/padding.rs
@@ -4,8 +4,6 @@
 //! appropriate sizes for efficient FFT calculations. Padding is
 //! crucial for correctly implementing convolution via FFT.
 
-use std::fmt::Debug;
-
 use ndarray::{
     Array, ArrayBase, Data, Dim, IntoDimension, Ix, RemoveAxis, SliceArg, SliceInfo, SliceInfoElem,
 };
@@ -36,7 +34,7 @@ pub fn data<T, S, const N: usize>(
     fft_size: [usize; N],
 ) -> Array<T, Dim<[Ix; N]>>
 where
-    T: NumAssign + Copy + Debug,
+    T: NumAssign + Copy,
     S: Data<Elem = T>,
     Dim<[Ix; N]>: RemoveAxis,
     [Ix; N]: IntoDimension<Dim = Dim<[Ix; N]>>,
@@ -82,7 +80,7 @@ pub fn kernel<'a, T, S, const N: usize>(
     fft_size: [usize; N],
 ) -> Array<T, Dim<[Ix; N]>>
 where
-    T: NumAssign + Copy + Debug + 'a,
+    T: NumAssign + Copy + 'a,
     S: Data<Elem = T>,
     [Ix; N]: IntoDimension<Dim = Dim<[Ix; N]>>,
     Dim<[Ix; N]>: RemoveAxis,

--- a/src/conv_fft/processor/mod.rs
+++ b/src/conv_fft/processor/mod.rs
@@ -46,14 +46,14 @@ impl_conv_fft_num!(i8, i16, i32, i64, i128, isize, f32, f64);
 /// # Example
 ///
 /// ```rust
-/// use ndarray_conv::conv_fft::processor::get as get_processor;
+/// use ndarray_conv::GetProcessor;
 ///
 /// // Get a processor for f32 real values
-/// let mut proc = get_processor::<f32, f32>();
+/// let mut proc = GetProcessor::<f32, f32>::get_processor();
 ///
 /// // Get a processor for Complex<f32> values
 /// use num::Complex;
-/// let mut proc_complex = get_processor::<f32, Complex<f32>>();
+/// let mut proc_complex = GetProcessor::<f32, Complex<f32>>::get_processor();
 /// ```
 pub fn get<T: FftNum, InElem: GetProcessor<T, InElem>>() -> impl Processor<T, InElem> {
     InElem::get_processor()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,9 @@ mod padding;
 pub(crate) use padding::ExplicitPadding;
 
 pub use conv::ConvExt;
-pub use conv_fft::{get_processor as get_fft_processor, ConvFFTExt, Processor as FftProcessor};
+pub use conv_fft::{
+    get_processor as get_fft_processor, ConvFFTExt, GetProcessor, Processor as FftProcessor,
+};
 pub use dilation::{ReverseKernel, WithDilation};
 
 /// Specifies the convolution mode, which determines the output size.


### PR DESCRIPTION
Allows for other library authors to be generic over `ConvFFT` trait.